### PR TITLE
Update 22_field_api.md

### DIFF
--- a/docs/22_field_api.md
+++ b/docs/22_field_api.md
@@ -1,6 +1,6 @@
 ## `chz.field`
 
-`chz.field takes the following parameters:
+`chz.field` takes the following parameters:
 
 #### `default`
 


### PR DESCRIPTION
This pull request includes a minor correction to the `docs/22_field_api.md` file. The change fixes a formatting issue in the documentation by adding a missing backtick.

* [`docs/22_field_api.md`](diffhunk://#diff-3ea3c37d06fb4b05607a8f317420a312536903132a067b81cd181d44a5cac261L3-R3): Corrected the formatting of the `chz.field` code identifier by adding a missing backtick.